### PR TITLE
Modify go-build tag

### DIFF
--- a/calico/go-build/0.85/Makefile
+++ b/calico/go-build/0.85/Makefile
@@ -3,7 +3,8 @@
 REGISTRY?=lcr.loongnix.cn
 ORGANIZATION?=calico
 REPOSITORY?=go-build
-TAG?=v0.85
+VCODE?=v0.85
+TAG?=v0.85-sid
 LATEST?=false
 
 IMAGE=$(REGISTRY)/$(ORGANIZATION)/$(REPOSITORY):$(patsubst v%,%,$(TAG))
@@ -16,7 +17,7 @@ PATCH=0001-add-loong64-support-abi-2.0.patch
 default: image
 
 src/$(SOURCE):
-	git clone -q -b $(TAG) --depth=1 $(SOURCE_URL) $@
+	git clone -q -b $(VCODE) --depth=1 $(SOURCE_URL) $@
 	cd $@ && \
 		git apply ../../$(PATCH)
 


### PR DESCRIPTION
go-build基础镜像golang:1.19-sid制作，所以这里在tag后添加sid后缀，便于区分